### PR TITLE
Use queue conf

### DIFF
--- a/pbs/job.py
+++ b/pbs/job.py
@@ -42,10 +42,12 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
 
     """
 
+    # default location for the queue config file
+    QUEUE_CONFIG = "../queue.conf"
 
     def __init__(self, name="STDIN", account=None, nodes=None, ppn=None, walltime=None, #pylint: disable=too-many-arguments, too-many-locals
                  pmem=None, qos=None, queue=None, exetime=None, message="a", email=None,
-                 priority="0", command=None, auto=False, substr=None, software=None):
+                 priority="0", command=None, auto=False, substr=None, software=None, queue_conf=QUEUE_CONFIG):
 
         if substr != None:
             self.read(substr)
@@ -133,7 +135,32 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
         # jobID
         self.jobID = None   #pylint: disable=invalid-name
 
+        # Add parameters from queue conf if not already have value
+        if queue_conf:
+            self.read_queue_conf(queue_conf)
+
     #
+
+    def read_queue_conf(self, q_conf):
+        """
+        Reads a queue config file and updates job parameters accordingly
+        :param q_conf: path to queue config file
+        :return: -
+        """
+        conf_params = set(["queue", "account", "nodes", "ppn",
+                           "walltime", "pmem", "qos", "exetime",
+                           "email", "priority"])
+
+        with open(q_conf) as f:
+            for line in f:
+                if line.startswith("#"):
+                    continue
+                param, val = line.strip().split("=", max=1)
+                if param not in conf_params:
+                    print("Ignoring unrecognized queue config parameter %s" % param)
+                else:
+                    if not getattr(self, param):    # only set value if current value is None
+                        setattr(self, param, val)
 
     def sub_string(self):   #pylint: disable=too-many-branches
         """ Write Job as a string suitable for self.software """

--- a/pbs/job.py
+++ b/pbs/job.py
@@ -43,7 +43,7 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
     """
 
     # default location for the queue config file
-    QUEUE_CONFIG = "../queue.conf"
+    QUEUE_CONFIG = os.path.expanduser("~") + "/.queue.conf" 
 
     def __init__(self, name="STDIN", account=None, nodes=None, ppn=None, walltime=None, #pylint: disable=too-many-arguments, too-many-locals
                  pmem=None, qos=None, queue=None, exetime=None, message="a", email=None,
@@ -76,10 +76,10 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
         self.account = account
 
         # number of nodes to request
-        self.nodes = int(nodes)
+        self.nodes = nodes
 
         # number of processors per node to request
-        self.ppn = int(ppn)
+        self.ppn = ppn
 
         # string walltime for job (HH:MM:SS)
         self.walltime = walltime
@@ -140,6 +140,8 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
         # Add parameters from queue conf if not already have value
         if queue_conf:
             self.read_queue_conf(queue_conf)
+        self.nodes = int(self.nodes)
+        self.ppn = int(self.ppn)
 
     #
 
@@ -157,7 +159,7 @@ class Job(object):  #pylint: disable=too-many-instance-attributes
             for line in f:
                 if line.startswith("#"):
                     continue
-                param, val = line.strip().split("=", max=1)
+                param, val = line.strip().split("=",1)
                 if param not in conf_params:
                     print("Ignoring unrecognized queue config parameter %s" % param)
                 else:

--- a/scripts/configure_queue.py
+++ b/scripts/configure_queue.py
@@ -30,6 +30,6 @@ conf_params["email"] = raw_input("What is your E-mail address? (for notification
 
 with open(conf_path,'w') as fo:
     for par in conf_params:
-        if conf_params[par]:
+        if conf_params[par] is not None:
             print("%s=%s" %(par, conf_params[par]), file=fo)
 print("Queue configuration created at %s" % conf_path)

--- a/scripts/configure_queue.py
+++ b/scripts/configure_queue.py
@@ -1,0 +1,34 @@
+from __future__ import print_function
+import sys
+
+if len(sys.argv) > 1:
+    conf_path = sys.argv[1]
+else:
+    conf_path = "queue.conf"
+print("Welcome to the queue configuration wizard."
+      "Please insert the following default values."
+      "If you don't want to set a default value for"
+      "a parameter, simply hit Return.")
+
+conf_params = {
+    "queue": None,
+    "account": None,
+    "nodes": 1,
+    "ppn": 1,
+    "walltime": None,
+    "pmem": None,
+    "qos": None,
+    "email": None,
+    "priority": 0
+}
+conf_params["queue"] = raw_input("What is the default queue name?")
+conf_params["account"] = raw_input("What is the default account name?")
+conf_params["walltime"] = raw_input("What is the default job walltime?")
+conf_params["qos"] = raw_input("What is the default Quality of Service?")
+conf_params["email"] = raw_input("What is your E-mail address? (for notifications)")
+
+with open(conf_path,'w') as fo:
+    for par in conf_params:
+        if conf_params[par]:
+            print("%s=%s" %(par, conf_params[par]), file=fo)
+print("Queue configuration created at %s" % conf_path)

--- a/scripts/configure_queue.py
+++ b/scripts/configure_queue.py
@@ -6,9 +6,9 @@ if len(sys.argv) > 1:
     conf_path = sys.argv[1]
 else:
     conf_path = expanduser("~") + "/.queue.conf"
-print("Welcome to the queue configuration wizard."
-      "Please insert the following default values."
-      "If you don't want to set a default value for"
+print("Welcome to the queue configuration wizard.\n"
+      "Please insert the following default values.\n"
+      "If you don't want to set a default value for\n"
       "a parameter, simply hit Return.")
 
 conf_params = {

--- a/scripts/configure_queue.py
+++ b/scripts/configure_queue.py
@@ -1,10 +1,11 @@
 from __future__ import print_function
 import sys
+from os.path import expanduser
 
 if len(sys.argv) > 1:
     conf_path = sys.argv[1]
 else:
-    conf_path = "queue.conf"
+    conf_path = expanduser("~") + "/.queue.conf"
 print("Welcome to the queue configuration wizard."
       "Please insert the following default values."
       "If you don't want to set a default value for"

--- a/scripts/configure_queue.py
+++ b/scripts/configure_queue.py
@@ -21,11 +21,11 @@ conf_params = {
     "email": None,
     "priority": 0
 }
-conf_params["queue"] = raw_input("What is the default queue name?")
-conf_params["account"] = raw_input("What is the default account name?")
-conf_params["walltime"] = raw_input("What is the default job walltime?")
-conf_params["qos"] = raw_input("What is the default Quality of Service?")
-conf_params["email"] = raw_input("What is your E-mail address? (for notifications)")
+conf_params["queue"] = raw_input("What is the default queue name?\n")
+conf_params["account"] = raw_input("What is the default account name?\n")
+conf_params["walltime"] = raw_input("What is the default job walltime?\n")
+conf_params["qos"] = raw_input("What is the default Quality of Service?\n")
+conf_params["email"] = raw_input("What is your E-mail address? (for notifications)\n")
 
 with open(conf_path,'w') as fo:
     for par in conf_params:


### PR DESCRIPTION
A new feature that allows to use a configuration with defaults to job parameters, so the user doesn't have to provide them every time they initialize a job.